### PR TITLE
feat: Make UnsecuredHeader work without json feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "geonetworking"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 authors = ["Kevin Westphal<westphal@consider-it.de>"]
 keywords = ["its", "v2x", "etsi", "geonetworking"]
@@ -24,13 +24,11 @@ nom = { version = "7.1", default-features = false, features = ["alloc"] }
 nom-bitvec = { package = "bitvec-nom2", version = "0.2.0" }
 num = { version = "0.4", default-features = false }
 num-traits = { version = "0.2", default-features = false }
+
 # "json" feature dependencies
-serde = { version = "1.0", default-features = false, features = [
-    "derive",
-], optional = true }
-serde_json = { version = "1.0", default-features = false, features = [
-    "alloc",
-], optional = true }
+serde = { version = "1.0", default-features = false, features = ["derive"], optional = true }
+serde_json = { version = "1.0", default-features = false, features = ["alloc"], optional = true }
+
 # "validate" feature dependencies
 ecdsa = { version = "0.16.9", default-features = false, features = ["verifying"], optional = true }
 openssl-sys = { version = "0.9", optional = true }
@@ -40,4 +38,3 @@ p384 = { version = "0.13.0", default-features = false, features = ["ecdsa"], opt
 sha2 = { version = "0.10.8", default-features = false, optional = true }
 sm2 = { version = "0.13.3", default-features = false, features = ["dsa"], optional = true }
 sm3 = { version = "0.4.2", default-features = false, optional = true }
-

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -104,20 +104,20 @@ decode!(LSReply);
 decode!(Certificate<'s>);
 decode!(ToBeSignedData<'s>);
 
-#[cfg(feature = "json")]
 /// Helper struct for decoding unsecured GeoNetworking headers from JSON.
 /// This crate focuses on zero-copy decoding from binary packets,
 /// therefore, JSON deserialization features are limited to a
 /// subset of GeoNetworking types.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "json", derive(Serialize, Deserialize))]
 pub struct UnsecuredHeader {
     pub basic: BasicHeader,
     pub common: CommonHeader,
     pub extended: Option<ExtendedHeader>,
 }
 
-#[cfg(feature = "json")]
 impl UnsecuredHeader {
+    #[cfg(feature = "json")]
     /// Tries to deserialize an unsecured GeoNetworking header
     /// from JSON.
     /// ### Usage
@@ -142,7 +142,7 @@ impl UnsecuredHeader {
                 extended: self.extended,
                 payload,
             }),
-            false => Err(EncodeError::Json(alloc::format!(
+            false => Err(EncodeError::Common(alloc::format!(
                 "Payload length {} does not match `payload_length` field {} in Common Header",
                 payload.len(),
                 self.common.payload_length

--- a/src/encode.rs
+++ b/src/encode.rs
@@ -12,6 +12,7 @@ use super::*;
 #[derive(Debug)]
 pub enum EncodeError {
     Unsupported(alloc::string::String),
+    Common(alloc::string::String),
     #[cfg(feature = "json")]
     Json(alloc::string::String),
 }
@@ -20,6 +21,7 @@ impl EncodeError {
     pub fn message(&self) -> &str {
         match self {
             Self::Unsupported(message) => message,
+            Self::Common(message) => message,
             #[cfg(feature = "json")]
             Self::Json(message) => message,
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,6 @@ pub(crate) mod util;
 #[cfg(feature = "validate")]
 mod validate;
 
-#[cfg(feature = "json")]
 pub use decode::UnsecuredHeader;
 pub use decode::{Decode, DecodeError, Decoded};
 pub use encode::{Encode, EncodeError, Encoder};


### PR DESCRIPTION
There's not really a need why everyone using this library needs to pull in JSON dependencies just to decode and encode UPER.

To mostly keep backwards compatibility, the newly added "json" feature is enabled by default. But a new `EncodeError` type was added to properly reflect what's done in `UnsecuredHeader::with_payload()` because that has nothing to do with JSON as far as I can see.