### PR TITLE
fix(validate): Move brainpool validation away from openSSL

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "geonetworking"
-version = "0.2.1"
+version = "0.3.0-rc.1"
 edition = "2021"
 authors = ["Kevin Westphal<westphal@consider-it.de>", "consider it GmbH"]
 keywords = ["its", "v2x", "etsi", "geonetworking"]
@@ -15,7 +15,7 @@ documentation = "https://docs.rs/geonetworking"
 [features]
 default = ["json", "validate"]
 json = ["dep:serde_json", "serde", "bytes/serde"]
-validate = ["ecdsa", "openssl", "openssl-sys", "p256", "p384", "sha2", "sm2", "sm3", "generic-array"]
+validate = ["ecdsa", "p256", "p384", "bp256", "bp384", "sha2", "sm2", "sm3"]
 
 [dependencies]
 bitvec = { version = "1.0", default-features = false, features = ["alloc"] }
@@ -30,15 +30,14 @@ serde = { version = "1.0", default-features = false, features = ["derive"], opti
 serde_json = { version = "1.0", default-features = false, features = ["alloc"], optional = true }
 
 # "validate" feature dependencies
-ecdsa = { version = "0.16.9", default-features = false, features = ["verifying"], optional = true }
-generic-array = { version = "=0.14.7", optional = true } # workaround until ecdsa is updated
-openssl-sys = { version = "0.9", optional = true }
-openssl = { version = "0.10", optional = true }
-p256 = { version = "0.13.2", default-features = false, features = ["ecdsa"], optional = true }
-p384 = { version = "0.13.1", default-features = false, features = ["ecdsa"], optional = true }
-sha2 = { version = "0.10.9", default-features = false, optional = true }
-sm2 = { version = "0.13.3", default-features = false, features = ["dsa"], optional = true }
-sm3 = { version = "0.4.2", default-features = false, optional = true }
+ecdsa = { version = "=0.17.0-rc.14", default-features = false, features = ["algorithm"], optional = true }
+p256  = { version = "=0.14.0-rc.6",  default-features = false, features = ["ecdsa"], optional = true }
+p384  = { version = "=0.14.0-rc.6",  default-features = false, features = ["ecdsa"], optional = true }
+bp256 = { version = "=0.14.0-rc.6",  default-features = false, features = ["ecdsa", "arithmetic", "sha256"], optional = true }
+bp384 = { version = "=0.14.0-rc.6",  default-features = false, features = ["ecdsa", "arithmetic", "sha384"], optional = true }
+sm2   = { version = "=0.14.0-rc.6",  default-features = false, features = ["dsa", "arithmetic"], optional = true }
+sha2  = { version = "=0.11.0-rc.4",  default-features = false, optional = true }
+sm3   = { version = "=0.5.0-rc.4",   default-features = false, optional = true }
 
 [dev-dependencies]
 pretty_assertions = "1.4.1"

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -10,16 +10,7 @@ use ecdsa::{
     VerifyingKey,
 };
 use num::Integer;
-use openssl::{
-    bn::{BigNum, BigNumContext},
-    ec::{EcKey, EcPoint},
-    ecdsa::EcdsaSig,
-};
-use p256::{AffinePoint as P256AffinePoint, EncodedPoint as P256EncodedPoint, NistP256};
-use p384::{AffinePoint as P384AffinePoint, EncodedPoint as P384EncodedPoint, NistP384};
-use sha2::{digest::generic_array::GenericArray, Digest, Sha256, Sha384};
-use sm2::{dsa::VerifyingKey as Sm2VerifyingKey, AffinePoint as Sm2AffinePoint};
-use sm3::Sm3;
+use sha2::{Digest, Sha256, Sha384};
 
 pub trait Validate {
     ///  The `Validate` trait exposes a `validate` method that checks whether the implementing type is valid.
@@ -229,7 +220,7 @@ fn sha384(data: &[u8]) -> Vec<u8> {
 }
 
 fn sm3(data: &[u8]) -> Vec<u8> {
-    let mut hasher = Sm3::new();
+    let mut hasher = sm3::Sm3::new();
     hasher.update(data);
     hasher.finalize().as_slice().to_vec()
 }
@@ -241,44 +232,83 @@ fn ecdsa_brainpool_p256_r1(
     msg: &[u8],
     encoded_certificate: Option<&[u8]>,
 ) -> Result<ValidationResult, ValidationError> {
-    let mut ctx = BigNumContext::new().unwrap();
-    let curve = openssl::ec::EcGroup::from_curve_name(openssl::nid::Nid::BRAINPOOL_P256R1).unwrap();
-    let point = match curve_point {
-        EccP256CurvePoint::CompressedY0(x) => {
-            EcPoint::from_bytes(&curve, &[vec![0x02], x.to_vec()].concat(), &mut ctx).unwrap()
-        }
-        EccP256CurvePoint::CompressedY1(x) => {
-            EcPoint::from_bytes(&curve, &[vec![0x03], x.to_vec()].concat(), &mut ctx).unwrap()
-        }
-        _ => panic!("Verifying key must be indicated in compressed-y, or uncompressed form!",),
-    };
-    let verifying_key = EcKey::from_public_key(&curve, &point).unwrap();
-    verifying_key.check_key().unwrap();
     let r_unwrapped = match r {
-        EccP256CurvePoint::XOnly(x) => x,
         EccP256CurvePoint::Fill(()) => {
             return Ok(ValidationResult::Failure {
                 reason: "R value of signature is not given!".into(),
             })
         }
-        EccP256CurvePoint::CompressedY0(x) => x,
-        EccP256CurvePoint::CompressedY1(x) => x,
-        EccP256CurvePoint::UncompressedP256(EccP256CurvePointUncompressedP256 { x, .. }) => x,
+        EccP256CurvePoint::XOnly(x)
+        | EccP256CurvePoint::CompressedY0(x)
+        | EccP256CurvePoint::CompressedY1(x)
+        | EccP256CurvePoint::UncompressedP256(EccP256CurvePointUncompressedP256 { x, .. }) => x,
     };
-    let signature = EcdsaSig::from_private_components(
-        BigNum::from_slice(r_unwrapped).unwrap(),
-        BigNum::from_slice(s).unwrap(),
+
+    let signature = ecdsa::Signature::<bp256::BrainpoolP256r1>::from_scalars(
+        bp256::FieldBytes::try_from(*r_unwrapped)
+            .map_err(|err| ValidationError::InvalidInput(format!("Invalid R length: {err:?}")))?,
+        bp256::FieldBytes::try_from(s)
+            .map_err(|err| ValidationError::InvalidInput(format!("Invalid S length: {err:?}")))?,
     )
     .unwrap();
-    match signature.verify(
+
+    let verifying_key = match curve_point {
+        EccP256CurvePoint::CompressedY0(x) => {
+            let affine = bp256::r1::AffinePoint::decompress(
+                &bp256::FieldBytes::try_from(*x).map_err(|err| {
+                    ValidationError::InvalidInput(format!(
+                        "Invalid verifying key compressed-y0 length: {err:?}"
+                    ))
+                })?,
+                Choice::from(0),
+            )
+            .unwrap();
+            VerifyingKey::from_affine(affine)
+                .map_err(|e| ValidationError::InvalidInput(format!("{e:?}")))
+        }
+        EccP256CurvePoint::CompressedY1(x) => {
+            let affine = bp256::r1::AffinePoint::decompress(
+                &bp256::FieldBytes::try_from(*x).map_err(|err| {
+                    ValidationError::InvalidInput(format!(
+                        "Invalid verifying key compressed-y1 length: {err:?}"
+                    ))
+                })?,
+                Choice::from(1),
+            )
+            .unwrap();
+            VerifyingKey::from_affine(affine)
+                .map_err(|e| ValidationError::InvalidInput(format!("{e:?}")))
+        }
+        EccP256CurvePoint::UncompressedP256(EccP256CurvePointUncompressedP256 { x, y }) => {
+            let encoded = bp256::r1::EncodedPoint::from_affine_coordinates(
+                &bp256::FieldBytes::try_from(*x).map_err(|err| {
+                    ValidationError::InvalidInput(format!(
+                        "Invalid verifying key X length: {err:?}"
+                    ))
+                })?,
+                &bp256::FieldBytes::try_from(*y).map_err(|err| {
+                    ValidationError::InvalidInput(format!(
+                        "Invalid verifying key Y length: {err:?}"
+                    ))
+                })?,
+                false,
+            );
+            VerifyingKey::from_encoded_point(&encoded)
+                .map_err(|e| ValidationError::InvalidInput(format!("{e:?}")))
+        }
+        _ => Err(ValidationError::InvalidInput(
+            "Verifying key must be indicated in compressed-y, or uncompressed form!".into(),
+        )),
+    }?;
+
+    match verifying_key.verify(
         &[sha256(msg), sha256(encoded_certificate.unwrap_or(&[]))].concat(),
-        &verifying_key,
+        &signature,
     ) {
-        Ok(true) => Ok(ValidationResult::Success),
-        Ok(false) => Ok(ValidationResult::Failure {
-            reason: "Signature verification failed!".into(),
+        Ok(()) => Ok(ValidationResult::Success),
+        Err(e) => Ok(ValidationResult::Failure {
+            reason: format!("{e:?}"),
         }),
-        Err(e) => Err(ValidationError::InvalidInput(e.to_string())),
     }
 }
 
@@ -289,44 +319,83 @@ fn ecdsa_brainpool_p384_r1(
     msg: &[u8],
     encoded_certificate: Option<&[u8]>,
 ) -> Result<ValidationResult, ValidationError> {
-    let mut ctx = BigNumContext::new().unwrap();
-    let curve = openssl::ec::EcGroup::from_curve_name(openssl::nid::Nid::BRAINPOOL_P384R1).unwrap();
-    let point = match curve_point {
-        EccP384CurvePoint::CompressedY0(x) => {
-            EcPoint::from_bytes(&curve, &[vec![0x02], x.to_vec()].concat(), &mut ctx).unwrap()
-        }
-        EccP384CurvePoint::CompressedY1(x) => {
-            EcPoint::from_bytes(&curve, &[vec![0x03], x.to_vec()].concat(), &mut ctx).unwrap()
-        }
-        _ => panic!("Verifying key must be indicated in compressed-y, or uncompressed form!",),
-    };
-    let verifying_key = EcKey::from_public_key(&curve, &point).unwrap();
-    verifying_key.check_key().unwrap();
     let r_unwrapped = match r {
-        EccP384CurvePoint::XOnly(x) => x,
         EccP384CurvePoint::Fill(()) => {
             return Ok(ValidationResult::Failure {
                 reason: "R value of signature is not given!".into(),
             })
         }
-        EccP384CurvePoint::CompressedY0(x) => x,
-        EccP384CurvePoint::CompressedY1(x) => x,
-        EccP384CurvePoint::UncompressedP384(EccP384CurvePointUncompressedP384 { x, .. }) => x,
+        EccP384CurvePoint::XOnly(x)
+        | EccP384CurvePoint::CompressedY0(x)
+        | EccP384CurvePoint::CompressedY1(x)
+        | EccP384CurvePoint::UncompressedP384(EccP384CurvePointUncompressedP384 { x, .. }) => x,
     };
-    let signature = EcdsaSig::from_private_components(
-        BigNum::from_slice(r_unwrapped).unwrap(),
-        BigNum::from_slice(s).unwrap(),
+
+    let signature = ecdsa::Signature::<bp384::BrainpoolP384r1>::from_scalars(
+        bp384::FieldBytes::try_from(*r_unwrapped)
+            .map_err(|err| ValidationError::InvalidInput(format!("Invalid R length: {err:?}")))?,
+        bp384::FieldBytes::try_from(s)
+            .map_err(|err| ValidationError::InvalidInput(format!("Invalid S length: {err:?}")))?,
     )
     .unwrap();
-    match signature.verify(
-        &[sha384(msg), sha384(encoded_certificate.unwrap_or(&[]))].concat(),
-        &verifying_key,
+
+    let verifying_key = match curve_point {
+        EccP384CurvePoint::CompressedY0(x) => {
+            let affine = bp384::r1::AffinePoint::decompress(
+                &bp384::FieldBytes::try_from(*x).map_err(|err| {
+                    ValidationError::InvalidInput(format!(
+                        "Invalid verifying key compressed-y0 length: {err:?}"
+                    ))
+                })?,
+                Choice::from(0),
+            )
+            .unwrap();
+            VerifyingKey::from_affine(affine)
+                .map_err(|e| ValidationError::InvalidInput(format!("{e:?}")))
+        }
+        EccP384CurvePoint::CompressedY1(x) => {
+            let affine = bp384::r1::AffinePoint::decompress(
+                &bp384::FieldBytes::try_from(*x).map_err(|err| {
+                    ValidationError::InvalidInput(format!(
+                        "Invalid verifying key compressed-y1 length: {err:?}"
+                    ))
+                })?,
+                Choice::from(1),
+            )
+            .unwrap();
+            VerifyingKey::from_affine(affine)
+                .map_err(|e| ValidationError::InvalidInput(format!("{e:?}")))
+        }
+        EccP384CurvePoint::UncompressedP384(EccP384CurvePointUncompressedP384 { x, y }) => {
+            let encoded = bp384::r1::EncodedPoint::from_affine_coordinates(
+                &bp384::FieldBytes::try_from(*x).map_err(|err| {
+                    ValidationError::InvalidInput(format!(
+                        "Invalid verifying key X length: {err:?}"
+                    ))
+                })?,
+                &bp384::FieldBytes::try_from(*y).map_err(|err| {
+                    ValidationError::InvalidInput(format!(
+                        "Invalid verifying key Y length: {err:?}"
+                    ))
+                })?,
+                false,
+            );
+            VerifyingKey::from_encoded_point(&encoded)
+                .map_err(|e| ValidationError::InvalidInput(format!("{e:?}")))
+        }
+        _ => Err(ValidationError::InvalidInput(
+            "Verifying key must be indicated in compressed-y, or uncompressed form!".into(),
+        )),
+    }?;
+
+    match verifying_key.verify(
+        &[sha256(msg), sha256(encoded_certificate.unwrap_or(&[]))].concat(),
+        &signature,
     ) {
-        Ok(true) => Ok(ValidationResult::Success),
-        Ok(false) => Ok(ValidationResult::Failure {
-            reason: "Signature verification failed!".into(),
+        Ok(()) => Ok(ValidationResult::Success),
+        Err(e) => Ok(ValidationResult::Failure {
+            reason: format!("{e:?}"),
         }),
-        Err(e) => Err(ValidationError::InvalidInput(e.to_string())),
     }
 }
 
@@ -338,37 +407,66 @@ fn ecdsa_nist_p256(
     encoded_certificate: Option<&[u8]>,
 ) -> Result<ValidationResult, ValidationError> {
     let r_unwrapped = match r {
-        EccP256CurvePoint::XOnly(x) => x,
         EccP256CurvePoint::Fill(()) => {
             return Ok(ValidationResult::Failure {
                 reason: "R value of signature is not given!".into(),
             })
         }
-        EccP256CurvePoint::CompressedY0(x) => x,
-        EccP256CurvePoint::CompressedY1(x) => x,
-        EccP256CurvePoint::UncompressedP256(EccP256CurvePointUncompressedP256 { x, .. }) => x,
+        EccP256CurvePoint::XOnly(x)
+        | EccP256CurvePoint::CompressedY0(x)
+        | EccP256CurvePoint::CompressedY1(x)
+        | EccP256CurvePoint::UncompressedP256(EccP256CurvePointUncompressedP256 { x, .. }) => x,
     };
 
-    let signature = ecdsa::Signature::<NistP256>::from_scalars(
-        *GenericArray::from_slice(r_unwrapped),
-        *GenericArray::from_slice(s),
+    let signature = ecdsa::Signature::<p256::NistP256>::from_scalars(
+        p256::FieldBytes::try_from(*r_unwrapped)
+            .map_err(|err| ValidationError::InvalidInput(format!("Invalid R length: {err:?}")))?,
+        p256::FieldBytes::try_from(s)
+            .map_err(|err| ValidationError::InvalidInput(format!("Invalid S length: {err:?}")))?,
     )
     .unwrap();
 
     let verifying_key = match curve_point {
         EccP256CurvePoint::CompressedY0(x) => {
-            let affine = P256AffinePoint::decompress((*x).into(), Choice::from(0)).unwrap();
+            let affine = p256::AffinePoint::decompress(
+                &p256::FieldBytes::try_from(*x).map_err(|err| {
+                    ValidationError::InvalidInput(format!(
+                        "Invalid verifying key compressed-y0 length: {err:?}"
+                    ))
+                })?,
+                Choice::from(0),
+            )
+            .unwrap();
             VerifyingKey::from_affine(affine)
                 .map_err(|e| ValidationError::InvalidInput(format!("{e:?}")))
         }
         EccP256CurvePoint::CompressedY1(x) => {
-            let affine = P256AffinePoint::decompress((*x).into(), Choice::from(1)).unwrap();
+            let affine = p256::AffinePoint::decompress(
+                &p256::FieldBytes::try_from(*x).map_err(|err| {
+                    ValidationError::InvalidInput(format!(
+                        "Invalid verifying key compressed-y1 length: {err:?}"
+                    ))
+                })?,
+                Choice::from(1),
+            )
+            .unwrap();
             VerifyingKey::from_affine(affine)
                 .map_err(|e| ValidationError::InvalidInput(format!("{e:?}")))
         }
         EccP256CurvePoint::UncompressedP256(EccP256CurvePointUncompressedP256 { x, y }) => {
-            let encoded =
-                P256EncodedPoint::from_affine_coordinates((*x).into(), (*y).into(), false);
+            let encoded = p256::EncodedPoint::from_affine_coordinates(
+                &p256::FieldBytes::try_from(*x).map_err(|err| {
+                    ValidationError::InvalidInput(format!(
+                        "Invalid verifying key X length: {err:?}"
+                    ))
+                })?,
+                &p256::FieldBytes::try_from(*y).map_err(|err| {
+                    ValidationError::InvalidInput(format!(
+                        "Invalid verifying key Y length: {err:?}"
+                    ))
+                })?,
+                false,
+            );
             VerifyingKey::from_encoded_point(&encoded)
                 .map_err(|e| ValidationError::InvalidInput(format!("{e:?}")))
         }
@@ -396,37 +494,66 @@ fn ecdsa_nist_p384(
     encoded_certificate: Option<&[u8]>,
 ) -> Result<ValidationResult, ValidationError> {
     let r_unwrapped = match r {
-        EccP384CurvePoint::XOnly(x) => x,
         EccP384CurvePoint::Fill(()) => {
             return Ok(ValidationResult::Failure {
                 reason: "R value of signature is not given!".into(),
             })
         }
-        EccP384CurvePoint::CompressedY0(x) => x,
-        EccP384CurvePoint::CompressedY1(x) => x,
-        EccP384CurvePoint::UncompressedP384(EccP384CurvePointUncompressedP384 { x, .. }) => x,
+        EccP384CurvePoint::XOnly(x)
+        | EccP384CurvePoint::CompressedY0(x)
+        | EccP384CurvePoint::CompressedY1(x)
+        | EccP384CurvePoint::UncompressedP384(EccP384CurvePointUncompressedP384 { x, .. }) => x,
     };
 
-    let signature = ecdsa::Signature::<NistP384>::from_scalars(
-        *GenericArray::from_slice(r_unwrapped),
-        *GenericArray::from_slice(s),
+    let signature = ecdsa::Signature::<p384::NistP384>::from_scalars(
+        p384::FieldBytes::try_from(*r_unwrapped)
+            .map_err(|err| ValidationError::InvalidInput(format!("Invalid R length: {err:?}")))?,
+        p384::FieldBytes::try_from(s)
+            .map_err(|err| ValidationError::InvalidInput(format!("Invalid S length: {err:?}")))?,
     )
     .unwrap();
 
     let verifying_key = match curve_point {
         EccP384CurvePoint::CompressedY0(x) => {
-            let affine = P384AffinePoint::decompress((*x).into(), Choice::from(0)).unwrap();
+            let affine = p384::AffinePoint::decompress(
+                &p384::FieldBytes::try_from(*x).map_err(|err| {
+                    ValidationError::InvalidInput(format!(
+                        "Invalid verifying key compressed-y0 length: {err:?}"
+                    ))
+                })?,
+                Choice::from(0),
+            )
+            .unwrap();
             VerifyingKey::from_affine(affine)
                 .map_err(|e| ValidationError::InvalidInput(format!("{e:?}")))
         }
         EccP384CurvePoint::CompressedY1(x) => {
-            let affine = P384AffinePoint::decompress((*x).into(), Choice::from(1)).unwrap();
+            let affine = p384::AffinePoint::decompress(
+                &p384::FieldBytes::try_from(*x).map_err(|err| {
+                    ValidationError::InvalidInput(format!(
+                        "Invalid verifying key compressed-y1 length: {err:?}"
+                    ))
+                })?,
+                Choice::from(1),
+            )
+            .unwrap();
             VerifyingKey::from_affine(affine)
                 .map_err(|e| ValidationError::InvalidInput(format!("{e:?}")))
         }
         EccP384CurvePoint::UncompressedP384(EccP384CurvePointUncompressedP384 { x, y }) => {
-            let encoded =
-                P384EncodedPoint::from_affine_coordinates((*x).into(), (*y).into(), false);
+            let encoded = p384::EncodedPoint::from_affine_coordinates(
+                &p384::FieldBytes::try_from(*x).map_err(|err| {
+                    ValidationError::InvalidInput(format!(
+                        "Invalid verifying key X length: {err:?}"
+                    ))
+                })?,
+                &p384::FieldBytes::try_from(*y).map_err(|err| {
+                    ValidationError::InvalidInput(format!(
+                        "Invalid verifying key Y length: {err:?}"
+                    ))
+                })?,
+                false,
+            );
             VerifyingKey::from_encoded_point(&encoded)
                 .map_err(|e| ValidationError::InvalidInput(format!("{e:?}")))
         }
@@ -454,29 +581,51 @@ fn ecdsa_sm2(
     encoded_certificate: Option<&[u8]>,
 ) -> Result<ValidationResult, ValidationError> {
     let signature = sm2::dsa::Signature::from_scalars(
-        *GenericArray::from_slice(r),
-        *GenericArray::from_slice(s),
+        sm2::FieldBytes::try_from(r)
+            .map_err(|err| ValidationError::InvalidInput(format!("Invalid R length: {err:?}")))?,
+        sm2::FieldBytes::try_from(s)
+            .map_err(|err| ValidationError::InvalidInput(format!("Invalid S length: {err:?}")))?,
     )
     .unwrap();
 
     let verifying_key = match curve_point {
         EccP256CurvePoint::CompressedY0(x) => {
-            let affine = Sm2AffinePoint::decompress((*x).into(), Choice::from(0)).unwrap();
-            Sm2VerifyingKey::from_affine("verifier", affine)
+            let affine = sm2::AffinePoint::decompress(
+                &sm2::FieldBytes::try_from(*x).map_err(|err| {
+                    ValidationError::InvalidInput(format!(
+                        "Invalid verifying key compressed-y0 length: {err:?}"
+                    ))
+                })?,
+                Choice::from(0),
+            )
+            .unwrap();
+            sm2::dsa::VerifyingKey::from_affine("verifier", affine)
                 .map_err(|e| ValidationError::InvalidInput(format!("{e:?}")))
         }
         EccP256CurvePoint::CompressedY1(x) => {
-            let affine = Sm2AffinePoint::decompress((*x).into(), Choice::from(1)).unwrap();
-            Sm2VerifyingKey::from_affine("verifier", affine)
+            let affine = sm2::AffinePoint::decompress(
+                &sm2::FieldBytes::try_from(*x).map_err(|err| {
+                    ValidationError::InvalidInput(format!(
+                        "Invalid verifying key compressed-y1 length: {err:?}"
+                    ))
+                })?,
+                Choice::from(1),
+            )
+            .unwrap();
+            sm2::dsa::VerifyingKey::from_affine("verifier", affine)
                 .map_err(|e| ValidationError::InvalidInput(format!("{e:?}")))
         }
         EccP256CurvePoint::UncompressedP256(EccP256CurvePointUncompressedP256 { x, y }) => {
-            let affine = Sm2AffinePoint::decompress(
-                (*x).into(),
+            let affine = sm2::AffinePoint::decompress(
+                &sm2::FieldBytes::try_from(*x).map_err(|err| {
+                    ValidationError::InvalidInput(format!(
+                        "Invalid verifying key uncompressed X length: {err:?}"
+                    ))
+                })?,
                 Choice::from(u8::from(!y.last().unwrap().is_even())),
             )
             .unwrap();
-            Sm2VerifyingKey::from_affine("verifier", affine)
+            sm2::dsa::VerifyingKey::from_affine("verifier", affine)
                 .map_err(|e| ValidationError::InvalidInput(format!("{e:?}")))
         }
         _ => Err(ValidationError::InvalidInput(
@@ -497,6 +646,8 @@ fn ecdsa_sm2(
 
 #[cfg(test)]
 mod tests {
+    use crate::Decode as _;
+
     use super::*;
 
     #[test]
@@ -551,5 +702,106 @@ mod tests {
                 ])
             )
         );
+    }
+
+    #[test]
+    // Cohda demo cert CAM with full cert
+    fn validates_nist_p256_cam() {
+        let data: &'static [u8] = &[
+            0x12, 0x00, 0x05, 0x01, 0x03, 0x81, 0x00, 0x40, 0x03, 0x80, 0x5f, 0x20, 0x50, 0x02,
+            0x80, 0x00, 0x3b, 0x01, 0x00, 0x14, 0x00, 0x06, 0x42, 0x7e, 0x75, 0x45, 0x23, 0x30,
+            0x3e, 0xbe, 0x08, 0x1f, 0xf3, 0x49, 0x66, 0x05, 0xfa, 0x99, 0x4c, 0x80, 0x00, 0x02,
+            0x20, 0x00, 0x00, 0x00, 0x00, 0x07, 0xd1, 0x00, 0x00, 0x02, 0x02, 0x7e, 0x75, 0x45,
+            0x23, 0xbe, 0x08, 0x40, 0x5a, 0xb3, 0x06, 0x4c, 0xce, 0x28, 0x8d, 0x69, 0x86, 0xaa,
+            0x6a, 0xa0, 0x00, 0x34, 0x2e, 0xd0, 0x48, 0x22, 0x0f, 0xa0, 0x05, 0xad, 0xbf, 0xe9,
+            0xea, 0x77, 0x33, 0xff, 0x01, 0xff, 0xfa, 0x00, 0x28, 0x33, 0x00, 0x00, 0x1c, 0x00,
+            0x69, 0x00, 0x4b, 0x31, 0xf6, 0x00, 0x27, 0x80, 0x40, 0x01, 0x24, 0x00, 0x02, 0x79,
+            0x8c, 0x75, 0x19, 0x83, 0x74, 0x81, 0x01, 0x01, 0x80, 0x03, 0x00, 0x80, 0x5d, 0x5d,
+            0xcb, 0xee, 0xfb, 0xe7, 0xd2, 0x2d, 0x30, 0x83, 0x00, 0x00, 0x00, 0x00, 0x00, 0x29,
+            0x84, 0x9d, 0x05, 0x86, 0x00, 0x01, 0xe0, 0x01, 0x07, 0x80, 0x01, 0x24, 0x81, 0x04,
+            0x03, 0x01, 0xff, 0xfc, 0x80, 0x01, 0x25, 0x81, 0x05, 0x04, 0x01, 0xff, 0xff, 0xff,
+            0x80, 0x01, 0x8c, 0x81, 0x05, 0x04, 0x02, 0xff, 0xff, 0xe0, 0x00, 0x01, 0x8d, 0x80,
+            0x02, 0x02, 0x7e, 0x81, 0x02, 0x01, 0x01, 0x80, 0x02, 0x02, 0x7f, 0x81, 0x02, 0x01,
+            0x01, 0x00, 0x02, 0x03, 0xff, 0x80, 0x80, 0x83, 0x7b, 0x2f, 0x6b, 0x07, 0x93, 0xc0,
+            0xd8, 0x89, 0x44, 0x7f, 0xa6, 0xe3, 0xa5, 0x7a, 0x4d, 0xca, 0x9c, 0x3f, 0xe8, 0x3e,
+            0xa5, 0x25, 0xfd, 0x11, 0x61, 0x6e, 0x0d, 0xfd, 0xe9, 0x91, 0x97, 0x39, 0x81, 0x80,
+            0x28, 0x13, 0x79, 0x86, 0x20, 0xa7, 0x29, 0xcc, 0xe6, 0x7d, 0x8d, 0x70, 0x1a, 0x26,
+            0x94, 0x8d, 0x64, 0x35, 0x61, 0x02, 0xd1, 0xd1, 0x99, 0xfb, 0x58, 0xfa, 0x7f, 0xaa,
+            0x70, 0xa9, 0x49, 0xf6, 0x6f, 0x12, 0x84, 0xb5, 0xd3, 0x83, 0xcf, 0x62, 0xa2, 0x7c,
+            0x3a, 0x89, 0x45, 0x73, 0x57, 0x6f, 0x5e, 0x4a, 0xef, 0x50, 0x6c, 0xe6, 0x0d, 0xf1,
+            0xfe, 0x68, 0x70, 0x05, 0x0d, 0x17, 0xa0, 0x12, 0x80, 0x82, 0xdf, 0x57, 0x00, 0xe7,
+            0xbf, 0x19, 0x6e, 0x1d, 0x1d, 0xcc, 0x9c, 0xf7, 0xfe, 0x55, 0x41, 0xd4, 0x53, 0x98,
+            0x6d, 0x95, 0x82, 0x49, 0x3c, 0xad, 0x52, 0x26, 0x55, 0xdf, 0xcc, 0x89, 0x7c, 0x23,
+            0xd2, 0x8e, 0x9e, 0x93, 0x3c, 0x76, 0x9d, 0xf3, 0xf7, 0x18, 0x1b, 0x02, 0x7a, 0x0f,
+            0x80, 0x3c, 0xfb, 0xc2, 0x37, 0x43, 0x3f, 0x8d, 0x5b, 0x7e, 0x83, 0x7d, 0x9e, 0x9d,
+            0x38, 0xd0, 0x62, 0xe6,
+        ];
+
+        let decoded = Packet::decode(data).unwrap();
+        assert_eq!(Ok(ValidationResult::Success), decoded.decoded.validate());
+    }
+
+    #[test]
+    // Cohda demo cert CAM with digest
+    fn validates_nist_p256_cam_digest() {
+        let data: &'static [u8] = &[
+            0x12, 0x00, 0x05, 0x01, 0x03, 0x81, 0x00, 0x40, 0x03, 0x80, 0x54, 0x20, 0x50, 0x02,
+            0x80, 0x00, 0x30, 0x01, 0x00, 0x14, 0x00, 0x06, 0x42, 0x7e, 0x75, 0x45, 0x23, 0x30,
+            0x3e, 0xbe, 0xd0, 0x1f, 0xf3, 0x49, 0x68, 0x05, 0xfa, 0x99, 0x49, 0x80, 0x0c, 0x02,
+            0x20, 0x00, 0x00, 0x00, 0x00, 0x07, 0xd1, 0x00, 0x00, 0x02, 0x02, 0x7e, 0x75, 0x45,
+            0x23, 0xbe, 0xd0, 0x00, 0x5a, 0xb3, 0x06, 0x4d, 0x0e, 0x28, 0x8d, 0x69, 0x26, 0xae,
+            0x6a, 0xe0, 0x00, 0x34, 0x2d, 0x92, 0x48, 0x22, 0x0f, 0xa0, 0x00, 0x98, 0xbf, 0xe9,
+            0xea, 0x6f, 0x33, 0xff, 0x01, 0xff, 0xfa, 0x00, 0x28, 0x33, 0x00, 0x40, 0x01, 0x24,
+            0x00, 0x02, 0x79, 0x8c, 0x75, 0x1b, 0x05, 0xc6, 0x80, 0xe7, 0x3f, 0x07, 0x42, 0x7e,
+            0x75, 0x45, 0x23, 0x80, 0x83, 0x6f, 0xc4, 0xa9, 0x4f, 0xb0, 0xe0, 0x1d, 0xd7, 0x66,
+            0xc3, 0x28, 0x1d, 0xfd, 0x38, 0x06, 0x55, 0xa8, 0x4c, 0xc4, 0x46, 0xc8, 0x7b, 0x33,
+            0x75, 0x6d, 0x56, 0xfc, 0x26, 0x08, 0x6b, 0x55, 0x15, 0xac, 0x23, 0x8b, 0xfe, 0xd1,
+            0x70, 0x21, 0x71, 0x6e, 0x6c, 0x95, 0x7c, 0x6e, 0xf7, 0xb5, 0xa1, 0x5f, 0x6e, 0x89,
+            0x24, 0xfc, 0x21, 0x6e, 0xd4, 0x8f, 0xc2, 0x9a, 0x51, 0x94, 0xba, 0xd0, 0x7f,
+        ];
+
+        let decoded = Packet::decode(data).unwrap();
+
+        assert!(matches!(
+            decoded.decoded.validate(),
+            Err(ValidationError::Unsupported(_))
+        ));
+    }
+
+    #[test]
+    // Some CAM with Brainpool P256r1 certificate
+    fn validates_brainpool_p256r1_cam() {
+        let data: &'static [u8] = &[
+            0x12, 0x00, 0x1a, 0x02, 0x03, 0x81, 0x00, 0x40, 0x03, 0x80, 0x74, 0x20, 0x40, 0x01,
+            0x00, 0x00, 0x40, 0x02, 0x00, 0x33, 0x9f, 0x00, 0x00, 0x3c, 0x00, 0x00, 0x50, 0x56,
+            0xa2, 0x42, 0x5e, 0x16, 0x80, 0xb8, 0x27, 0x1c, 0x0e, 0x3f, 0x53, 0x09, 0x30, 0xe5,
+            0x2f, 0x80, 0x00, 0x00, 0x00, 0x1c, 0x0e, 0x5f, 0x5a, 0x09, 0x30, 0xdc, 0xf1, 0x03,
+            0xe8, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x07, 0xd2, 0x07, 0xd2, 0x02, 0x01, 0x00,
+            0x00, 0x9c, 0x3f, 0xc3, 0x00, 0x00, 0x00, 0x00, 0x8a, 0x32, 0x14, 0x42, 0xd0, 0x17,
+            0x04, 0xe5, 0x10, 0xb4, 0x05, 0xc1, 0x3d, 0x1b, 0x34, 0x85, 0xa7, 0x47, 0xaa, 0xef,
+            0x1f, 0xff, 0xff, 0xfe, 0x11, 0xdb, 0xba, 0x1f, 0x40, 0x0f, 0x01, 0xe2, 0x00, 0x40,
+            0x00, 0x04, 0x80, 0x00, 0x60, 0x00, 0x1c, 0x73, 0x87, 0x7f, 0xda, 0x08, 0x3b, 0xc7,
+            0x38, 0x50, 0x01, 0x25, 0x00, 0x02, 0x79, 0x27, 0xd8, 0xb3, 0x39, 0x38, 0x1c, 0x0e,
+            0x3f, 0x53, 0x09, 0x30, 0xe5, 0x2f, 0x10, 0x00, 0x81, 0x01, 0x01, 0x80, 0x03, 0x00,
+            0x80, 0xfb, 0x9f, 0xe6, 0x57, 0x1f, 0x7c, 0xe7, 0xf9, 0x10, 0x83, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x29, 0x77, 0x14, 0xd9, 0x84, 0x00, 0xa8, 0x01, 0x02, 0x80, 0x01, 0x25,
+            0x81, 0x05, 0x04, 0x01, 0xff, 0xff, 0xff, 0x80, 0x01, 0x8b, 0x81, 0x07, 0x06, 0x01,
+            0xc0, 0x40, 0x01, 0xff, 0xf8, 0x80, 0x81, 0x82, 0x37, 0x9e, 0x96, 0x25, 0xd2, 0xdd,
+            0xb4, 0x4a, 0xe3, 0x00, 0xf1, 0x7c, 0x1c, 0x34, 0xb9, 0xaf, 0xb6, 0x91, 0x24, 0x8a,
+            0x2d, 0xec, 0xf4, 0x72, 0x1f, 0x49, 0x6e, 0x47, 0x0e, 0x98, 0x86, 0x47, 0x80, 0x80,
+            0xd7, 0xa0, 0xad, 0xd8, 0x85, 0xff, 0xae, 0x32, 0x76, 0xdb, 0xed, 0x6b, 0x90, 0x5d,
+            0x8d, 0x72, 0xbe, 0xf3, 0x71, 0x6b, 0xc3, 0xf9, 0x83, 0xc6, 0x65, 0xff, 0xda, 0x8d,
+            0x16, 0xba, 0x47, 0x2d, 0xdf, 0x46, 0xa7, 0x38, 0xa4, 0xd4, 0x6d, 0xdb, 0x24, 0xac,
+            0xad, 0xa6, 0x08, 0x90, 0xd8, 0x5b, 0xf7, 0x5b, 0xf1, 0xc9, 0xe8, 0x06, 0x59, 0x2c,
+            0xfb, 0x71, 0xc6, 0x23, 0xc4, 0xd9, 0x8b, 0x2f, 0x81, 0x80, 0x9e, 0x35, 0xa5, 0x16,
+            0x38, 0xc0, 0xbe, 0x4d, 0x45, 0x7e, 0xcf, 0x50, 0x34, 0x4b, 0xfe, 0x89, 0xef, 0x37,
+            0x10, 0x04, 0x38, 0xec, 0x33, 0x60, 0x77, 0x86, 0x47, 0xb1, 0xe5, 0x9d, 0x9b, 0xc6,
+            0x2c, 0xe3, 0xb8, 0x2a, 0x24, 0xfd, 0x39, 0xee, 0x04, 0xac, 0x90, 0xe2, 0x19, 0x99,
+            0x6a, 0xa1, 0x37, 0x00, 0x57, 0x0c, 0x7c, 0x60, 0xc7, 0x30, 0x72, 0xde, 0x3d, 0xc7,
+            0x9a, 0xb7, 0x32, 0x60,
+        ];
+
+        let decoded = Packet::decode(data).unwrap();
+        assert_eq!(Ok(ValidationResult::Success), decoded.decoded.validate());
     }
 }


### PR DESCRIPTION
Somehow validation of packets signed with Brainpool P256R1 curves was always reporting an invalid signature.

The issue must be somewhere in the OpenSSL-based implementation of the signature validation since only Brainpool uses this approach while NIST validation uses the [p256](https://crates.io/crates/p256) and [p384](https://crates.io/crates/p384) crates.
Since there are similar crates for Brainpool curves, this PR changes the implementation to use the same suite of crypto crates everywhere instead of OpenSSL.

Caveat: We need to use pre-release versions of these crates since the published version of the Brainpool crates doesn't have the required traits implemented.