### PR TITLE
chore(deps): Pin more dependencies to compile pre-release more reliably

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,5 +39,12 @@ sm2   = { version = "=0.14.0-rc.7",  default-features = false, features = ["dsa"
 sha2  = { version = "=0.11.0-rc.5",  default-features = false, optional = true }
 sm3   = { version = "=0.5.0-rc.5",   default-features = false, optional = true }
 
+# temporarily locked sub-dependencies
+primefield        = { version = "=0.14.0-rc.7", default-features = false, optional = true }
+primeorder        = { version = "=0.14.0-rc.7", default-features = false, optional = true }
+rustcrypto-ff     = { version = "=0.14.0-rc.0", default-features = false, optional = true }
+rustcrypto-group  = { version = "=0.14.0-rc.0", default-features = false, optional = true }
+crypto-bigint     = { version = "=0.7.0-rc.28", default-features = false, optional = true }
+
 [dev-dependencies]
 pretty_assertions = "1.4.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,20 +31,20 @@ serde_json = { version = "1.0", default-features = false, features = ["alloc"], 
 
 # "validate" feature dependencies
 ecdsa = { version = "=0.17.0-rc.16", default-features = false, features = ["algorithm"], optional = true }
-p256  = { version = "=0.14.0-rc.7",  default-features = false, features = ["ecdsa"], optional = true }
-p384  = { version = "=0.14.0-rc.7",  default-features = false, features = ["ecdsa"], optional = true }
-bp256 = { version = "=0.14.0-rc.7",  default-features = false, features = ["ecdsa", "arithmetic", "sha256"], optional = true }
-bp384 = { version = "=0.14.0-rc.7",  default-features = false, features = ["ecdsa", "arithmetic", "sha384"], optional = true }
-sm2   = { version = "=0.14.0-rc.7",  default-features = false, features = ["dsa", "arithmetic"], optional = true }
-sha2  = { version = "=0.11.0-rc.5",  default-features = false, optional = true }
-sm3   = { version = "=0.5.0-rc.5",   default-features = false, optional = true }
+p256  = { version = "=0.14.0-rc.8",  default-features = false, features = ["ecdsa"], optional = true }
+p384  = { version = "=0.14.0-rc.8",  default-features = false, features = ["ecdsa"], optional = true }
+bp256 = { version = "=0.14.0-rc.8",  default-features = false, features = ["ecdsa", "arithmetic", "sha256"], optional = true }
+bp384 = { version = "=0.14.0-rc.8",  default-features = false, features = ["ecdsa", "arithmetic", "sha384"], optional = true }
+sm2   = { version = "=0.14.0-rc.8",  default-features = false, features = ["dsa", "arithmetic"], optional = true }
+sha2  = { version = "=0.11.0",  default-features = false, optional = true }
+sm3   = { version = "=0.5.0",   default-features = false, optional = true }
 
 # temporarily locked sub-dependencies
-primefield        = { version = "=0.14.0-rc.7", default-features = false, optional = true }
-primeorder        = { version = "=0.14.0-rc.7", default-features = false, optional = true }
+primefield        = { version = "=0.14.0-rc.8", default-features = false, optional = true }
+primeorder        = { version = "=0.14.0-rc.8", default-features = false, optional = true }
 rustcrypto-ff     = { version = "=0.14.0-rc.0", default-features = false, optional = true }
 rustcrypto-group  = { version = "=0.14.0-rc.0", default-features = false, optional = true }
-crypto-bigint     = { version = "=0.7.0-rc.28", default-features = false, optional = true }
+crypto-bigint     = { version = "=0.7.3", default-features = false, optional = true }
 
 [dev-dependencies]
 pretty_assertions = "1.4.1"


### PR DESCRIPTION
The crypto libraries still take a while until they're released, but got new release-candidates with breaking changes.

I didn't manage to get `ecdsa` 0.17.0-rc.17 to compile, so only everything else was updated.